### PR TITLE
chore(renovate): bump all inputs, gate on CI

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,41 @@
+name: nix
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nix-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build darwin system
+    # aarch64-darwin runner; matches the flake system.
+    runs-on: macos-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      # Cache /nix/store across runs so uncached source builds
+      # (e.g. openscad) are restored instead of recompiled every PR.
+      - uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock', '**/*.nix') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+
+      - name: flake check
+        run: nix flake check --print-build-logs
+
+      # Build the actual system closure — the gate that proves
+      # `darwin-rebuild switch` will not break on this update.
+      - name: build darwin system
+        run: nix build '.#darwinConfigurations.JJ4M9J6X2M.system' --print-build-logs

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "reviewers": ["Automaat"],
+  "automerge": true,
+  "automergeStrategy": "squash",
+  "platformAutomerge": false,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true,
+    "schedule": ["* 0-5 * * 1"]
+  }
 }


### PR DESCRIPTION
## Motivation

`mise` (and `nixpkgs`/`nix-darwin`/`home-manager`) track a moving branch, so Renovate's recommended config never bumped them — `flake.lock` only refreshes via Lock File Maintenance, which was disabled. Result: the toolchain silently went stale until a manual `nix flake update`.

## Implementation information

- Enable `lockFileMaintenance` so Renovate runs `nix flake update` weekly and bumps every flake input. Combined with `config:recommended` (github-actions etc.), Renovate now bumps everything bumpable.
- Add a `nix` GitHub Actions workflow (macOS/aarch64 runner) that runs `nix flake check` and builds `.#darwinConfigurations.JJ4M9J6X2M.system` — the real gate proving `darwin-rebuild switch` won't break.
- Auto-merge stays on but `platformAutomerge: false`, so Renovate waits for the build to go green before merging (repo has no branch protection to enforce required checks).
- `/nix/store` cached across runs so the uncached openscad source build isn't recompiled every PR.
- All actions SHA-pinned with semver comments.

## Supporting documentation

n/a