### PR TITLE
chore(packages): openscad via homebrew cask

### DIFF
--- a/modules/casks.nix
+++ b/modules/casks.nix
@@ -18,6 +18,7 @@
   # 3D printing
   "freecad"
   "bambu-studio"
+  "openscad"
 
   # Development
   "visual-studio-code"

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -118,9 +118,6 @@ with pkgs; [
   # CLI utilities
   # gemini-cli  # Not in nixpkgs - install via npm/pip if needed
 
-  # 3D modeling
-  openscad
-
   # home assistant
   esphome
 ]


### PR DESCRIPTION
## Motivation

OpenSCAD has no aarch64-darwin binary in cache.nixos.org, so every `darwin-rebuild` (and CI build) compiles it from source (~30+ min, Qt/CGAL). It's the single biggest contributor to slow local rebuilds and slow CI.

## Implementation information

- Remove `openscad` from `modules/packages.nix` and add the `openscad` Homebrew cask (same 2021.01) to `modules/casks.nix`. Homebrew ships a prebuilt app, so nix no longer builds it. nix-darwin installs the cask at activation; it is not part of the nix system closure, so `nix build` (local + CI) skips it entirely.
- This PR's own CI build is the proof: no OpenSCAD compile step.

## Supporting documentation

n/a