### PR TITLE
fix(agents): link copilot instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/dotfiles/claude/build-agents.sh
+++ b/dotfiles/claude/build-agents.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Generate a self-contained AGENTS.md from the modular CLAUDE.md + rules/.
 # Claude inlines the rules/ links; Codex (~/.codex/AGENTS.md) and Copilot CLI
-# (~/AGENTS.md, parent-dir walk-up) load AGENTS.md verbatim and do NOT follow
-# markdown links — so the rule bodies must be inlined here. Re-run after editing
-# CLAUDE.md or rules/.
+# (~/.copilot/instructions/*.instructions.md) load a single file verbatim and do
+# NOT follow markdown links — so the rule bodies must be inlined here. Re-run
+# after editing CLAUDE.md or rules/.
 set -euo pipefail
 
 dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/dotfiles/claude/link.sh
+++ b/dotfiles/claude/link.sh
@@ -28,7 +28,10 @@ link "$src_dir/statusline-command.sh" "$HOME/.claude/statusline-command.sh"
 # Codex (global) — flat AGENTS.md; Codex does not follow markdown links.
 link "$src_dir/AGENTS.md" "$HOME/.codex/AGENTS.md"
 
-# Copilot CLI (global) — parent-dir walk-up reads ~/AGENTS.md for repos under ~.
+# Copilot CLI (global) — documented global instruction directory.
+link "$src_dir/AGENTS.md" "$HOME/.copilot/instructions/global.instructions.md"
+
+# Copilot CLI compatibility — older/global parent walk-up setups.
 link "$src_dir/AGENTS.md" "$HOME/AGENTS.md"
 
 echo "done."


### PR DESCRIPTION
## Motivation

> Changelog: fix(agents): link copilot instructions

Keep Copilot CLI instructions in its documented global directory while preserving the older root-level AGENTS.md setup.

## Implementation information

- Link generated AGENTS.md into ~/.copilot/instructions/global.instructions.md.
- Keep ~/AGENTS.md as a compatibility link.
- Add a repo-root AGENTS.md symlink to CLAUDE.md for agent instruction discovery.

## Supporting documentation

Validated with bash -n, git diff --check, and nix flake check.