### PR TITLE
chore(renovate): enable nix updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,15 +1,40 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    ":semanticCommitType(chore)",
+    ":semanticCommitScope(deps)"
   ],
+  "labels": ["dependencies", "automerge"],
   "reviewers": ["Automaat"],
   "automerge": true,
   "automergeStrategy": "squash",
   "platformAutomerge": false,
+  "nix": {
+    "enabled": true
+  },
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,
-    "schedule": ["* 0-5 * * 1"]
-  }
+    "schedule": ["* 0-5 * * 1"],
+    "commitMessageTopic": "flake.lock"
+  },
+  "packageRules": [
+    {
+      "description": "Keep Nix flake inputs updated as one tested toolchain bump.",
+      "matchManagers": ["nix"],
+      "groupName": "Nix flake inputs",
+      "groupSlug": "nix-flake-inputs",
+      "addLabels": ["nix"],
+      "automerge": true
+    },
+    {
+      "description": "Keep CI actions that build the Nix system current.",
+      "matchManagers": ["github-actions"],
+      "addLabels": ["github-actions"],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
## Motivation

Keep nixpkgs, nix-darwin, and home-manager fresh through Renovate with CI-backed PRs.

> Changelog: chore(renovate): enable nix updates

## Implementation information

Enabled Renovate's Nix manager, grouped flake inputs into one toolchain bump, and added labels used by the existing auto-merge workflow. Also labels GitHub Actions updates so Nix CI stays current.

## Supporting documentation

Renovate Nix manager docs: https://docs.renovatebot.com/modules/manager/nix/