### PR TITLE
chore(klaudiush): consolidate config into nix/xdg

### DIFF
--- a/dotfiles/klaudiush/config.toml
+++ b/dotfiles/klaudiush/config.toml
@@ -1,0 +1,82 @@
+# klaudiush global config — single source of truth (XDG: ~/.config/klaudiush/config.toml)
+# Merged from the former XDG + legacy ~/.klaudiush configs; legacy values win on overlap.
+
+# Git Validators
+[validators.git]
+
+# Git Add - blocks adding sensitive files
+[validators.git.add]
+enabled = true
+severity = "error"
+blocked_patterns = ["*.secret", "*.key", ".env"]
+
+# Git Commit - enforce flags, staging, conventional commits
+[validators.git.commit]
+enabled = true
+severity = "error"
+required_flags = ["-s", "-S"]
+check_staging_area = true
+enable_message_validation = true
+
+# Git Push - validates remote/branch; blocks direct pushes to main/master
+[validators.git.push]
+enabled = true
+severity = "error"
+blocked_branches = ["main", "master"]
+
+# Git PR - conventional commits, body validation
+[validators.git.pr]
+enabled = false
+severity = "error"
+title_max_length = 70
+enable_conventional_commits = true
+require_body = false
+
+# Git Branch - naming conventions
+[validators.git.branch]
+enabled = true
+severity = "error"
+protected_branches = ["main", "master"]
+require_type = true
+allow_uppercase = false
+
+# Git No-Verify - blocks --no-verify flag
+[validators.git.no_verify]
+enabled = true
+severity = "error"
+
+# File Validators
+[validators.file]
+
+
+# Linter Ignore - blocks linter ignore directives
+[validators.file.linter_ignore]
+enabled = true
+severity = "error"
+
+# AI Comments - blocks filler comments that only restate the code
+[validators.file.ai_comments]
+enabled = true
+severity = "error"
+
+# Secrets Detection
+[validators.secrets.secrets]
+enabled = false
+severity = "error"
+use_gitleaks = false
+block_on_detection = true
+max_file_size = 1048576  # 1MB in bytes
+# allow_list = ["test-fixtures/*", "mock-*"]
+
+[providers]
+
+[providers.claude]
+enabled = true
+
+[providers.codex]
+enabled = true
+experimental = true
+hooks_config_path = "/Users/marcin.skalski/Library/Application Support/orca/codex-runtime-home/home/hooks.json"
+
+[providers.gemini]
+enabled = false

--- a/modules/dotfiles/klaudiush.nix
+++ b/modules/dotfiles/klaudiush.nix
@@ -1,0 +1,7 @@
+{ ... }:
+
+{
+  # klaudiush validator config, single source of truth at the XDG location.
+  # Legacy ~/.klaudiush/config.toml is retired in favour of this file.
+  xdg.configFile."klaudiush/config.toml".source = ../../dotfiles/klaudiush/config.toml;
+}

--- a/modules/home.nix
+++ b/modules/home.nix
@@ -22,6 +22,7 @@ in {
     ./dotfiles/ghostty.nix
     ./dotfiles/hammerspoon.nix
     ./dotfiles/k9s.nix
+    ./dotfiles/klaudiush.nix
     ./dotfiles/mise.nix
     ./dotfiles/starship.nix
     ./dotfiles/ssh.nix


### PR DESCRIPTION
## Motivation

The klaudiush validator config had drifted across two files: the Nix
(home-manager) XDG config at `~/.config/klaudiush/config.toml` and a
hand-edited legacy `~/.klaudiush/config.toml`. The legacy file was
loaded as a walk-up *project* override, so it silently won for many
settings and only took effect when the working directory was under
`$HOME` — filler-comment blocking (`ai_comments`) did not fire outside
the home tree. The Nix source for the config had also been removed, so
the XDG file was a stale, unmanaged artifact.

## Implementation information

- Re-add `modules/dotfiles/klaudiush.nix` wiring the config via
  `xdg.configFile."klaudiush/config.toml"`, imported in `home.nix`.
- Add `dotfiles/klaudiush/config.toml` as the single merged source of
  truth (former XDG validator suite + legacy overrides).
- Enable `ai_comments` in the global layer so blocking works in every
  directory, not only under `$HOME`.
- Fold direct-push protection into the built-in validator via
  `blocked_branches = ["main", "master"]` instead of glob rules that
  false-positived on branches like `feature/main-*`.
- Drop the two hand-rolled AI-attribution rules; the built-in
  `block_ai_attribution` (default on) already covers them.

Verified with `darwin-rebuild build` and by activating the switch;
the legacy `~/.klaudiush/config.toml` has been removed.

## Supporting documentation

None.