### PR TITLE
feat(klaudiush): block force pushes

### DIFF
--- a/dotfiles/klaudiush/config.toml
+++ b/dotfiles/klaudiush/config.toml
@@ -58,7 +58,7 @@ priority = 100
 
 [rules.rules.match]
 validator_type = "git.push"
-command_pattern = '(^|\s)(--force(-with-lease|-if-includes)?|-f)($|=|\s)'
+command_pattern = 'git\s+push\b[^&|;]*(\s|=)(--force(-with-lease|-if-includes)?|-f)($|=|\s)'
 
 [rules.rules.action]
 type = "block"

--- a/dotfiles/klaudiush/config.toml
+++ b/dotfiles/klaudiush/config.toml
@@ -45,6 +45,26 @@ allow_uppercase = false
 enabled = true
 severity = "error"
 
+# Rules Engine - custom command-level policies
+[rules]
+enabled = true
+
+# Block all force pushes, including --force-with-lease / --force-if-includes and -f.
+[[rules.rules]]
+name = "block-force-push"
+description = "Block force pushes"
+enabled = true
+priority = 100
+
+[rules.rules.match]
+validator_type = "git.push"
+command_pattern = '(^|\s)(--force(-with-lease|-if-includes)?|-f)($|=|\s)'
+
+[rules.rules.action]
+type = "block"
+message = "Force push is blocked. Rebase/merge and push normally; a human must run any force push."
+reference = "GIT-FORCE"
+
 # File Validators
 [validators.file]
 


### PR DESCRIPTION
## Motivation

Agents should never force-push. The klaudiush push validator only supports `blocked_remotes`/`blocked_branches` — it has no force-flag detection, so force pushes to non-protected branches passed silently.

## Implementation information

Added a rules-engine policy (`block-force-push`) to the global klaudiush config that denies any `git push` using `--force`, `--force-with-lease`, `--force-if-includes`, or `-f`. Uses `validator_type = "git.push"` with a token-boundaried regex so branch names like `my-feature` don't false-positive.

Verified against the deployed config via `klaudiush --event PreToolUse`: all four force variants return `permissionDecision: deny`; a normal push is allowed.

## Supporting documentation

`type = "block"` action and `validator_type = "git.push"` + `command_pattern` matching follow klaudiush's own `examples/rules/advanced-patterns.toml` and rules integration tests.