### PR TITLE
chore(klaudiush): disable pattern tracking

### DIFF
--- a/dotfiles/klaudiush/config.toml
+++ b/dotfiles/klaudiush/config.toml
@@ -1,6 +1,10 @@
 # klaudiush global config — single source of truth (XDG: ~/.config/klaudiush/config.toml)
 # Merged from the former XDG + legacy ~/.klaudiush configs; legacy values win on overlap.
 
+# Failure pattern tracking — disabled to avoid writing .klaudiush/patterns.json into project repos
+[patterns]
+enabled = false
+
 # Git Validators
 [validators.git]
 


### PR DESCRIPTION
## Motivation

klaudiush's pattern-tracking system writes `.klaudiush/patterns.json` into every project root. It got accidentally committed into an upstream kuma PR. Disabling it prevents this class of leak.

## Implementation information

- Set `[patterns] enabled = false` in the global klaudiush config.

## Supporting documentation

Controlled by `KLAUDIUSH_PATTERNS_ENABLED` / `[patterns].enabled` (default true).